### PR TITLE
Update CORS headers so older IOS version can talk to it

### DIFF
--- a/vennthandler.py
+++ b/vennthandler.py
@@ -72,7 +72,8 @@ class VenntHandler(BaseHTTPRequestHandler):
     def do_OPTIONS(self):
         self.send_response(200)
         self.send_header('Access-Control-Allow-Origin', '*')
-        self.send_header('Access-Control-Allow-Headers', '*')
+        self.send_header('Access-Control-Allow-Headers',
+            'Accept,Accept-Encoding,Accept-Language,Connection,Content-Length,Content-Type,Host,Origin,Referer,User-Agent,X-Requested-With')
         self.send_header('Access-Control-Allow-Methods',
                          'OPTIONS, GET, HEAD, POST')
         self.send_header('Allow', 'OPTIONS, GET, HEAD, POST')


### PR DESCRIPTION
Replaces the wildcard with a list of supported headers - this should fix an issue I was running into trying to test this on an older ipad.